### PR TITLE
add simple string and fix newline

### DIFF
--- a/bin/smagenBot.js
+++ b/bin/smagenBot.js
@@ -143,10 +143,14 @@ smagenBot.prototype.makeAction = function (text) {
         require('../plugins/'+plugin)(param, function(objs, types) {
           for(var i in objs) {
             if(types[i] === "text") {
+
               var str = "";
               for(var key in objs[i]) {
-                str += key + ": "+query.escape(objs[i][key])+"%0A";
+                str += ((key!=="STRING") ? (key + ": ") : "") + 
+                  query.escape(objs[i][key]) +
+                  "\n";
               }
+
               self.sendAction('typing', function(err, res) {
                 if(!err) {
                   self.sendMessage(str);

--- a/plugins/string.js
+++ b/plugins/string.js
@@ -1,0 +1,20 @@
+/**
+ * @author carlo "blackout" denaro
+ * @desc string plugin example
+ * @link http://github.com/blackout314
+ */
+var request = require('request');
+
+var exec = function (param, cb) {
+  var error,
+  name = "String Plugin";
+
+  if(param) {
+      return cb([ {"STRING":"hi "+param} ], ["text"]);
+  } else {
+      return cb([ {"STRING":"hello everyone"} ], ["text"]);
+  }
+
+};
+
+module.exports = exec;


### PR DESCRIPTION
- fix return "new line" (don't work, return malformed message like 

```
0: p%0A1: r%0A2: o%0A3: v%0A4: a%0A5: p%0A6: r%0A7: o%0A8: v%0A9: a%0A
```
- add keyword for simple STRING
